### PR TITLE
Added a refresh method to the StreamBulider BLOC

### DIFF
--- a/lib/src/bloc_select.dart
+++ b/lib/src/bloc_select.dart
@@ -111,6 +111,13 @@ class SelectBloc {
     }
   }
 
+  //A way to externally trigger the BLOC to rerun the query.
+  //Very useful if you have a changing filter being used as part of the
+  //search query.
+  Future<void> reload() async {
+    return _getItems();
+  }
+
   Future<void> _getItems() async {
     List<Map<String, dynamic>> res;
 


### PR DESCRIPTION
Hello

I wrote a Flutter app where you could filter a search using an entered search string. It was very easy to hook up the TextEntry's onChanged callback to change the SelectBloc.where string to the new value.

However I could not find any way of triggering the Bloc to run the new query.
Since I was using the Bloc with a StreamBuilder it was not feasible to replace the current Bloc with a new Bloc instance.

So I added a refresh() method to call the SelectBloc's _getItems() method.

As I am sure that others will also be having these same issues, I am submitting this pull request to merge this change into the master repository.

Thank you for maintaining this great project.