### PR TITLE
Discard null values when converting to string map

### DIFF
--- a/lib/src/schema/models/dbmodels.dart
+++ b/lib/src/schema/models/dbmodels.dart
@@ -238,7 +238,7 @@ class DbModel {
 
   Map<String, String> _toStringsMap(Map<String, dynamic> map) {
     final res = <String, String>{};
-    map.forEach((String k, dynamic v) => res[k] = "$v");
+    map.forEach((String k, dynamic v) => v == null ? null : res[k] = "$v");
     return res;
   }
 


### PR DESCRIPTION
Hi!

I do sometimes use null values with my database models. Currently the _toStringsMap method converts them literally to 'null'. This leads to failed inserts when 'null' is saved into an int field for example. I've corrected the behaviour to discard those values completely.

Thanks!